### PR TITLE
Changed root dir structure to resemble entry structure

### DIFF
--- a/runner/src/main/kotlin/cc/t0ast/taskpipe/stages/running/ParallelPipelineRunner.kt
+++ b/runner/src/main/kotlin/cc/t0ast/taskpipe/stages/running/ParallelPipelineRunner.kt
@@ -23,6 +23,8 @@ class ParallelPipelineRunner(currentWorkingDirectory: File): PipelineRunner(curr
     private val taskWaitGroup = WaitGroup()
 
     override suspend fun run(pipeline: SegmentedPipeline) {
+        super.run(pipeline)
+
         LOGGER.fine("Running pipeline ${pipeline.name}")
 
         val producer = GlobalScope.launchTaskProducer(pipeline)
@@ -54,7 +56,7 @@ class ParallelPipelineRunner(currentWorkingDirectory: File): PipelineRunner(curr
             }
             else {
                 LOGGER.finer("Enqueueing individual segment $segment")
-                currentWorkingDirectory.listFiles().forEach { entryDir ->
+                contentDirectory.listFiles().forEach { entryDir ->
                     send(Task(entryDir, segment.jobs))
                     taskWaitGroup.add()
                     PRODUCER_LOGGER.finest("Enqueued task chain from segment $segment for entry $entryDir")

--- a/runner/src/main/kotlin/cc/t0ast/taskpipe/stages/running/PipelineRunner.kt
+++ b/runner/src/main/kotlin/cc/t0ast/taskpipe/stages/running/PipelineRunner.kt
@@ -3,6 +3,31 @@ package cc.t0ast.taskpipe.stages.running
 import cc.t0ast.taskpipe.stages.segmentation.SegmentedPipeline
 import java.io.File
 
-abstract class PipelineRunner(var currentWorkingDirectory: File) {
-    abstract suspend fun run(pipeline: SegmentedPipeline)
+abstract class PipelineRunner(currentWorkingDirectory: File) {
+
+    var currentWorkingDirectory: File = currentWorkingDirectory
+        set(value) {
+            field = value
+            updateDirectoryPointers()
+        }
+
+    lateinit var contentDirectory: File
+        private set
+
+    lateinit var moduleDataDirectory: File
+        private set
+
+    open suspend fun run(pipeline: SegmentedPipeline) {
+        this.contentDirectory.mkdirs()
+        this.moduleDataDirectory.mkdirs()
+    }
+
+    private fun updateDirectoryPointers() {
+        this.contentDirectory = File(this.currentWorkingDirectory, "content")
+        this.moduleDataDirectory = File(this.currentWorkingDirectory, "module_data")
+    }
+
+    init {
+        updateDirectoryPointers()
+    }
 }

--- a/runner/src/test/kotlin/cc/t0ast/taskpipe/stages/CompleteTest.kt
+++ b/runner/src/test/kotlin/cc/t0ast/taskpipe/stages/CompleteTest.kt
@@ -33,12 +33,16 @@ class CompleteTest {
         assert(rootDir.exists())
         assert(rootDir.isDirectory)
 
-        val entries = rootDir.list()
+        val contentDir = File(rootDir, "content")
+        assert(contentDir.exists())
+        assert(contentDir.isDirectory)
+
+        val entries = contentDir.list()
         assertEquals(AMOUNT_OF_ENTRIES_IN_RUN, entries.size)
 
         IntStream.rangeClosed(1, AMOUNT_OF_ENTRIES_IN_RUN).forEach { assert(entries.contains("entry$it")) }
 
-        entries.map { File(rootDir, it) }
+        entries.map { File(contentDir, it) }
                 .forEach { checkGeneratedEntryFilesystem(it) }
     }
 

--- a/runner/src/test/kotlin/cc/t0ast/taskpipe/stages/running/PipelineRunnerTest.kt
+++ b/runner/src/test/kotlin/cc/t0ast/taskpipe/stages/running/PipelineRunnerTest.kt
@@ -28,12 +28,16 @@ class PipelineRunnerTest {
         assert(rootDir.exists())
         assert(rootDir.isDirectory)
 
-        val entries = rootDir.list()
+        val contentDir = File(rootDir, "content")
+        assert(contentDir.exists())
+        assert(contentDir.isDirectory)
+
+        val entries = contentDir.list()
         assertEquals(AMOUNT_OF_ENTRIES_IN_RUN, entries.size)
 
         IntStream.range(0, AMOUNT_OF_ENTRIES_IN_RUN).forEach { assert(entries.contains("entry$it")) }
 
-        entries.map { File(rootDir, it) }
+        entries.map { File(contentDir, it) }
                 .forEach { checkGeneratedEntryFilesystem(it) }
     }
 

--- a/runner/src/test/kotlin/cc/t0ast/taskpipe/test_utils/modules/DummyEntryCreatorModule.kt
+++ b/runner/src/test/kotlin/cc/t0ast/taskpipe/test_utils/modules/DummyEntryCreatorModule.kt
@@ -11,8 +11,10 @@ class DummyEntryCreatorModule : Module() {
     override val supportedOperationModes: Array<OperationMode> = arrayOf(OperationMode.GROUP)
 
     override suspend fun run(workingDirectory: File, arguments: Map<String, Any>) {
+        val contentDir = File(workingDirectory, "content")
+
         IntStream.range(0, arguments[AMOUNT_OF_ENTRIES] as Int).forEach { entryIndex ->
-            val entryDir = File(workingDirectory, "entry$entryIndex")
+            val entryDir = File(contentDir, "entry$entryIndex")
             entryDir.mkdir()
 
             val entryContentDir = File(entryDir, "content")

--- a/runner/src/test/resources/example_pipeline/modules/mkentry/mkentry.sh
+++ b/runner/src/test/resources/example_pipeline/modules/mkentry/mkentry.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+cd content
+
 for (( i = 1; i <= $1; i++ ))
 do
 	mkdir entry$i
@@ -9,3 +12,4 @@ do
 	
 	cd ..
 done
+


### PR DESCRIPTION
Now the root directory has only two subfolders: content (where the
entries are stored) and module_data (where group module data is stored)

The root directory now resembles a single "group-entry"